### PR TITLE
Document the break selectors feature in the keymap example file

### DIFF
--- a/Example.sublime-keymap
+++ b/Example.sublime-keymap
@@ -8,6 +8,15 @@
 		}
 	},
 
+	// Convert to expanded format (break selectors)
+	{
+		"keys": ["ctrl+alt+b"],
+		"command": "css_format",
+		"args": {
+			"action": "expand-bs"
+		}
+	},
+
 	// Convert to compact format
 	{
 		"keys": ["ctrl+alt+]"],


### PR DESCRIPTION
I was searching on how to map the break selectors feature and had to look into the code to find the command. Specifying the break selectors feature in the example key map file will let the user know the overloads to the standard commands.
